### PR TITLE
Fix tests on environments which don't support ES6 syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "example": "examples"
   },
   "scripts": {
-    "test": " ./node_modules/.bin/mocha"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",

--- a/test/erroz.test.js
+++ b/test/erroz.test.js
@@ -167,7 +167,7 @@ describe("erroz", function () {
         });
 
         it("should return status = 'success' if statusCode is 2xx", function() {
-            let res = jSendError({
+            var res = jSendError({
                 statusCode: 201
             }, {});
 
@@ -175,7 +175,7 @@ describe("erroz", function () {
         });
 
         it("should return status = 'fail' if statusCode is 4xx", function() {
-            let res = jSendError({
+            var res = jSendError({
                 statusCode: 404
             }, {});
 
@@ -183,7 +183,7 @@ describe("erroz", function () {
         });
 
         it("should return status = 'error' if statusCode is 5xx", function() {
-            let res = jSendError({
+            var res = jSendError({
                 statusCode: 500
             }, {});
 
@@ -191,7 +191,7 @@ describe("erroz", function () {
         });
 
         it("should not overwrite a given status", function() {
-            let res = jSendError({
+            var res = jSendError({
                 statusCode: 500,
                 status: "success"
             }, {});
@@ -201,7 +201,7 @@ describe("erroz", function () {
         });
 
         it("should set status = 'error' if the statusCode is not a valid for jSend", function() {
-            let res = jSendError({
+            var res = jSendError({
                 statusCode: 301
             }, {});
 


### PR DESCRIPTION
Hey,

`let` is a bit unsupported on Node.js 0.12 and below :laughing: 

Ben