### PR TITLE
fix: publish TypeScript types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,7 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
-  - "4.2"
-  - "4.1"
-  - "4.0"
-  - "stable"
-  - "iojs"
+  - "20"
 
 script:
   - npm test
+  - npm run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: node_js
 node_js:
-  - "20"
+  - "0.10"
+  - "0.12"
+  - "4.2"
+  - "4.1"
+  - "4.0"
+  - "stable"
+  - "iojs"
 
 script:
   - npm test
-  - npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "erroz",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "erroz",
-      "version": "1.1.0",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.12",

--- a/package.json
+++ b/package.json
@@ -5,13 +5,6 @@
   "main": "dist/erroz.umd.js",
   "module": "dist/erroz.mjs",
   "types": "dist/main.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/main.d.ts",
-      "import": "./dist/erroz.mjs",
-      "require": "./dist/erroz.umd.js"
-    }
-  },
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -4,6 +4,14 @@
   "description": "Create abstract errors with meta-data, stack-traces and speaking error-messages",
   "main": "dist/erroz.umd.js",
   "module": "dist/erroz.mjs",
+  "types": "dist/main.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/main.d.ts",
+      "import": "./dist/erroz.mjs",
+      "require": "./dist/erroz.umd.js"
+    }
+  },
   "files": [
     "dist"
   ],
@@ -11,8 +19,10 @@
     "example": "examples"
   },
   "scripts": {
-    "build": "vite build",
-    "prepublishOnly": "vite build",
+    "build": "vite build && npm run build:types",
+    "build:types": "tsc -p tsconfig.build.json",
+    "prepack": "npm run build",
+    "prepublishOnly": "npm test",
     "test": "jest",
     "test:watch": "jest --watch"
   },

--- a/src/AbstractError.ts
+++ b/src/AbstractError.ts
@@ -5,6 +5,17 @@ export class AbstractError extends Error {
   constructor(message?: string) {
     super(message);
 
-    Error.captureStackTrace(this, AbstractError);
+    const captureStackTrace = (
+      Error as ErrorConstructor & {
+        captureStackTrace?: (
+          targetObject: object,
+          constructorOpt?: Function,
+        ) => void;
+      }
+    ).captureStackTrace;
+
+    if (captureStackTrace) {
+      captureStackTrace(this, AbstractError);
+    }
   }
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationDir": "dist",
+    "emitDeclarationOnly": true,
+    "types": []
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION

Update the package build and publish metadata so TypeScript declarations are generated and included in the npm package.

The source exports TypeScript types, but the package did not emit or publish declaration files. 

## What changed

- Added a top-level `types` entry pointing to `dist/main.d.ts`
- Added a declaration-only TypeScript build via `tsconfig.build.json`
- Updated `npm run build` to generate both JS bundles and `.d.ts` files
- Added `prepack` so `npm pack` / `npm publish` build the distributable package before packaging
- Made `Error.captureStackTrace` optional so generated declarations do not leak Node-only ambient types


The first declaration build also exposed `@types/node` through inherited `Error` static fields, which could break consumers that do not install Node types. The dedicated declaration build avoids that leak.
